### PR TITLE
Remove authentication and authorization middleware for blog route

### DIFF
--- a/src/routes/blogRouter.ts
+++ b/src/routes/blogRouter.ts
@@ -7,7 +7,7 @@ const router = express.Router();
 
 router.post("/blog", verifyJwtToken, authorizeRole("author"), createBlog);
 router.get("/blog", getAllBlogs);
-router.get("/blog/:id", verifyJwtToken, authorizeRole("author"), getBlogById);
+router.get("/blog/:id", getBlogById);
 router.put("/blog/:id/:status", verifyJwtToken, authorizeRole("admin"), updateBlogStatus);
 
 export default router;


### PR DESCRIPTION
- Removed verifyJwtToken middleware to allow access to the route without requiring a JWT token.
- Removed authorizeRole middleware to allow readers to access and view blog descriptions.